### PR TITLE
Improving Coordinator test

### DIFF
--- a/src/main/java/org/right_brothers/agents/CoordinatorAgent.java
+++ b/src/main/java/org/right_brothers/agents/CoordinatorAgent.java
@@ -4,9 +4,6 @@ import java.io.IOException;
 import java.util.List;
 import java.util.Optional;
 import java.util.Vector;
-
-import org.right_brothers.data.messages.CoordinatorMessage;
-
 import jade.core.behaviours.*;
 import jade.core.Agent;
 import jade.lang.acl.ACLMessage;
@@ -15,11 +12,11 @@ import jade.lang.acl.UnreadableException;
 
 @SuppressWarnings("serial")
 public class CoordinatorAgent extends Agent {
-    private List<CoordinatorMessage> messages;
+    private List<String> messages;
 
     protected void setup() {
         System.out.println("\tCoordinator-agent "+getAID().getLocalName()+" is born.");
-        messages = new Vector<CoordinatorMessage>();
+        messages = new Vector<String>();
 
         addBehaviour(new RequestsServer());
         addBehaviour(new InformServer());
@@ -40,28 +37,37 @@ public class CoordinatorAgent extends Agent {
             ACLMessage requestMessage = myAgent.receive(requestTemplate);
             if (requestMessage != null) {
                 String id = requestMessage.getContent();
-                System.out.println(String.format("\tReceived REQUEST: %s", id));
+                System.out.println(String.format("\t" + myAgent.getLocalName() + " received REQUEST: %s", id));
 
                 ACLMessage reply = requestMessage.createReply();
-                Optional<CoordinatorMessage> result = messages.stream()
-                 .filter(m -> id.equals(m.getId()))
-                 .findFirst();
-                try {
-                    if(result.isPresent()) {
-                        reply.setPerformative(ACLMessage.CONFIRM);
-                        reply.setContentObject(result.get());
-                    }else {
-                        reply.setPerformative(ACLMessage.REFUSE);
-                        reply.setContentObject(null);
-                    }
-                }catch(IOException e) {
-                    e.printStackTrace();
+                reply.setPerformative(ACLMessage.REFUSE);
+                reply.setContent(null);
+                String mess = this.isMessageConfirmable(id, messages); // Please add your logic here to decide when message can be termed as confirmed.
+                if (mess != null) {
+                    reply.setPerformative(ACLMessage.CONFIRM);
+                    reply.setContent(mess);
                 }
                 myAgent.send(reply);
             }
             else {
                 block();
             }
+        }
+
+        public String isMessageConfirmable(String id, List<String> msg) {
+            for (String m : msg) {
+                try {
+                    if (m.contains(id)) {
+                        return m;
+                    }
+                }
+                catch(NullPointerException e)
+                {
+                    System.out.println("m string in Null");
+                    return null;
+                }
+            }
+            return null;
         }
     }
 
@@ -75,16 +81,10 @@ public class CoordinatorAgent extends Agent {
 
             ACLMessage informMessage = myAgent.receive(informTemplate);
             if (informMessage != null) {
-                try {
-                    CoordinatorMessage data = (CoordinatorMessage)informMessage.getContentObject();
-                    messages.add(data);
-
-                    System.out.println(String.format("\tReceived INFORM: %s", data.getClass()));
-                    System.out.println("\tMessage: " + data.getId());
-                    System.out.println("\tCurrent messages list size: " + messages.size());
-                } catch (UnreadableException e) {
-                    e.printStackTrace();
-                }
+                String data = informMessage.getContent();
+                messages.add(data);
+                System.out.println("\t" + myAgent.getLocalName() + " received INFORM:" + data);
+                System.out.println("\t" + myAgent.getLocalName() + " current messages list size: " + messages.size());
                 ACLMessage reply = informMessage.createReply();
                 reply.setPerformative(ACLMessage.CONFIRM);
                 reply.setContent("Got your Object.");

--- a/src/main/java/org/right_brothers/agents/CoordinatorAgent.java
+++ b/src/main/java/org/right_brothers/agents/CoordinatorAgent.java
@@ -1,14 +1,11 @@
 package org.right_brothers.agents;
 
-import java.io.IOException;
 import java.util.List;
-import java.util.Optional;
 import java.util.Vector;
 import jade.core.behaviours.*;
 import jade.core.Agent;
 import jade.lang.acl.ACLMessage;
 import jade.lang.acl.MessageTemplate;
-import jade.lang.acl.UnreadableException;
 
 @SuppressWarnings("serial")
 public class CoordinatorAgent extends Agent {

--- a/src/main/java/org/right_brothers/agents/DummyAgent.java
+++ b/src/main/java/org/right_brothers/agents/DummyAgent.java
@@ -18,11 +18,6 @@ import jade.lang.acl.UnreadableException;
 import java.util.Arrays;
 import java.util.List;
 
-import org.right_brothers.data.messages.BakedProduct;
-import org.right_brothers.data.messages.CoordinatorMessage;
-import org.right_brothers.data.messages.Dough;
-import org.right_brothers.data.messages.UnbakedProduct;
-
 
 @SuppressWarnings("serial")
 public class DummyAgent extends Agent {
@@ -35,12 +30,12 @@ public class DummyAgent extends Agent {
 
         // TODO: always add counter after adding behaviour
         // This dummy agent acts like test agent
-        List<CoordinatorMessage> informMessages = Arrays.asList(
-        		new Dough("dough-1"),
-        		new BakedProduct("baked-1"),
-        		new UnbakedProduct("unbaked-1")
+        List<String> informMessages = Arrays.asList(
+        		new String("dough-1"),
+        		new String("baked-1"),
+        		new String("unbaked-1")
     		);
-        for(CoordinatorMessage msg: informMessages) {
+        for(String msg: informMessages) {
         	this.addBehaviour(new InformPerformer(msg));
         	this.counter++;
         }
@@ -78,14 +73,9 @@ public class DummyAgent extends Agent {
                 ACLMessage reply = myAgent.receive(mt);
                 if (reply != null) {
                     if (reply.getPerformative() == ACLMessage.CONFIRM) {
-                        System.out.println("\t" + myAgent.getLocalName() + " received confirmation from " + reply.getSender().getLocalName());
-                        try {
-                            CoordinatorMessage data = (CoordinatorMessage)reply.getContentObject();
-                            System.out.println(String.format("\tReceived CONFIRM: %s", data.getClass()));
-                            System.out.println("\tReply Message: " + data.getId());
-                        } catch (UnreadableException e) {
-                            e.printStackTrace();
-                        }
+                        System.out.println("\t" + myAgent.getLocalName() + " received CONFIRM from " + reply.getSender().getLocalName());
+                        String data = (String)reply.getContent();
+                        System.out.println("\t" + myAgent.getLocalName() + " Reply Message: " + data);
                         step = 2;
                     }
                     if (reply.getPerformative() == ACLMessage.REFUSE) {
@@ -116,9 +106,9 @@ public class DummyAgent extends Agent {
     private class InformPerformer extends Behaviour {
         private MessageTemplate mt;
         private int step = 0;
-        private CoordinatorMessage message;
+        private String message;
         
-        public InformPerformer(CoordinatorMessage message) {
+        public InformPerformer(String message) {
         	this.message = message;
         }
 
@@ -127,14 +117,9 @@ public class DummyAgent extends Agent {
             case 0:
                 ACLMessage inform = new ACLMessage(ACLMessage.INFORM);
                 inform.addReceiver(coordinator);
-
-                try {
-                    inform.setContentObject(message);
-                } catch(Exception e){
-                    e.printStackTrace();
-                }
+                inform.setContent(message);
                 inform.setConversationId("testing");
-                inform.setReplyWith("request"+ message.getId() +System.currentTimeMillis()); // Unique value
+                inform.setReplyWith("request"+ message +System.currentTimeMillis()); // Unique value
                 myAgent.send(inform);
                 mt = MessageTemplate.and(MessageTemplate.MatchConversationId("testing"),
                 MessageTemplate.MatchInReplyTo(inform.getReplyWith()));
@@ -145,7 +130,7 @@ public class DummyAgent extends Agent {
                 if (reply != null) {
                     if (reply.getPerformative() == ACLMessage.CONFIRM) {
                         System.out.println("\t" + myAgent.getLocalName() + " received confirmation from " + reply.getSender().getLocalName());
-                        System.out.println("\tReply Message: " + reply.getContent());
+                        System.out.println("\t" + myAgent.getLocalName() + " Reply Message: " + reply.getContent());
                         step = 2;
                     }
                     if (reply.getPerformative() == ACLMessage.REFUSE) {
@@ -163,7 +148,10 @@ public class DummyAgent extends Agent {
         }
         public boolean done() {
             if (step == 2) {
-            	myAgent.addBehaviour(new RequestPerformer(this.message.getId()));
+                counter --;
+                if (counter == 0){
+                    myAgent.addBehaviour(new shutdown());
+                }
                 return true;
             }
             return false;

--- a/src/main/java/org/right_brothers/agents/DummyAgent.java
+++ b/src/main/java/org/right_brothers/agents/DummyAgent.java
@@ -13,7 +13,6 @@ import jade.core.AID;
 import jade.core.behaviours.*;
 import jade.lang.acl.ACLMessage;
 import jade.lang.acl.MessageTemplate;
-import jade.lang.acl.UnreadableException;
 
 import java.util.Arrays;
 import java.util.List;
@@ -30,11 +29,7 @@ public class DummyAgent extends Agent {
 
         // TODO: always add counter after adding behaviour
         // This dummy agent acts like test agent
-        List<String> informMessages = Arrays.asList(
-        		new String("dough-1"),
-        		new String("baked-1"),
-        		new String("unbaked-1")
-    		);
+        List<String> informMessages = Arrays.asList("dough-1", "baked-1", "unbaked-1");
         for(String msg: informMessages) {
         	this.addBehaviour(new InformPerformer(msg));
         	this.counter++;


### PR DESCRIPTION
It basically removes the communication of objects and uses Strings instead. So that unnecessary objects can be avoided. This is done because now all messages are supposed to be strings.